### PR TITLE
Switch to CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.o
 *.til
 *.txt
+!CMakeLists.txt
 *.d
 *.out
 .vscode/*
 .git/*
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+project(sparrow LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(utils)
+add_subdirectory(html)
+add_subdirectory(css)
+add_subdirectory(style)
+add_subdirectory(layout)
+add_subdirectory(sdl)

--- a/css/CMakeLists.txt
+++ b/css/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(sparrow_css
+    css_parser.cc
+    css_element.cc
+)
+
+target_include_directories(sparrow_css
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(cssprog main.cc)
+target_link_libraries(cssprog sparrow_css)

--- a/html/CMakeLists.txt
+++ b/html/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(sparrow_html
+    html_parser.cc
+    dom.cc
+)
+
+target_include_directories(sparrow_html
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(htmlprog main.cc)
+target_link_libraries(htmlprog sparrow_html)

--- a/layout/CMakeLists.txt
+++ b/layout/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(sparrow_layout
+    layout_node.cc
+)
+
+target_include_directories(sparrow_layout
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(layoutprog main.cc)
+
+target_link_libraries(sparrow_layout
+    PUBLIC sparrow_utils sparrow_style sparrow_html sparrow_css
+)
+
+target_link_libraries(layoutprog sparrow_layout)

--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,15 @@ This is a project which I developed to learn the mechanism of web browsers. The 
 
 I mainly take [mbrubeck/robinson](https://github.com/mbrubeck/robinson) as reference when implementing this toy browser.
 
-Each part can be both compiled to a runnable program, or a library linked by others. To compile a runnable program, goto that part and run command:
+Each part can be built using CMake. A typical build of all components looks like
+this:
 
 ```
-$ make integrate # compile the runnable program
-$ make clean # clean this directory and other dependencies
+$ mkdir build && cd build
+$ cmake ..
+$ cmake --build .
 ```
+The resulting binaries are generated inside the `build` directory.
 The dependencies are as follows, once again, each part can be run and tested independently.
 
 a) html parser: itself

--- a/sdl/CMakeLists.txt
+++ b/sdl/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(sparrow_drawer
+    sdl_drawer.cc
+    sdl_drawer_interface.cc
+)
+
+target_include_directories(sparrow_drawer
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(Freetype REQUIRED)
+
+add_executable(drawerprog main.cc)
+
+target_link_libraries(sparrow_drawer
+    PUBLIC sparrow_layout SDL2::SDL2 SDL2_image::SDL2_image Freetype::Freetype
+)
+
+target_link_libraries(drawerprog sparrow_drawer)

--- a/style/CMakeLists.txt
+++ b/style/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(sparrow_style
+    style_node_parser.cc
+    style_node.cc
+)
+
+target_include_directories(sparrow_style
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(styleprog main.cc)
+
+target_link_libraries(sparrow_style
+    PUBLIC sparrow_utils sparrow_html sparrow_css
+)
+
+target_link_libraries(styleprog sparrow_style)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(sparrow_utils
+    font_manager.cc
+)
+
+target_include_directories(sparrow_utils
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+find_package(SDL2 REQUIRED)
+find_package(Freetype REQUIRED)
+
+target_link_libraries(sparrow_utils
+    PUBLIC SDL2::SDL2 SDL2::SDL2main Freetype::Freetype
+)


### PR DESCRIPTION
## Summary
- switch from ad-hoc Makefiles to a single modern CMake build
- add individual `CMakeLists.txt` to each component
- ignore build directory
- document the new build steps in `readme.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68543484216083299fe7028c39cc75ac