### PR TITLE
Prefix std types in headers

### DIFF
--- a/css/css_element.h
+++ b/css/css_element.h
@@ -6,25 +6,25 @@
 #include <iostream>
 #include <cstdint>
 
-using namespace std;
+
 
 namespace simple_browser_css {
 
 struct Selector {
-    string id;
-    string tag;
-    vector<string> class_list;
+    std::string id;
+    std::string tag;
+    std::vector<std::string> class_list;
 
-    string to_string();
+    std::string to_string();
 };
 
 struct Keyword {
-    string keyword;
+    std::string keyword;
 };
 
 struct Length {
     float data;
-    string unit;
+    std::string unit;
 };
 
 struct Color {
@@ -44,12 +44,12 @@ struct Value {
     ValueType type;    
     union {
         struct {
-            string keyword;            
+            std::string keyword;
         } Keyword;
 
         struct {
             float data;
-            string unit;
+            std::string unit;
         } Length;
 
         struct {
@@ -60,33 +60,33 @@ struct Value {
         } Color;
     };
 
-    Value(const string& kwd);
-    Value(const tuple<float, string>& length);
-    Value(const tuple<uint8_t, uint8_t, uint8_t, uint8_t>& color);
+    Value(const std::string& kwd);
+    Value(const std::tuple<float, std::string>& length);
+    Value(const std::tuple<uint8_t, uint8_t, uint8_t, uint8_t>& color);
     Value(const Value& v);
     Value();
     ~Value();
 
     bool operator==(const Value& v);
     float to_px() const;
-    string to_string();
+    std::string to_string();
 };
 
 struct Declaration {
-    string name;
+    std::string name;
     struct Value value;
 
-    Declaration(const string& name, const string& kwd);
-    Declaration(const string& name, const tuple<float, string>& length);
-    Declaration(const string& name, const tuple<uint8_t, uint8_t, uint8_t, uint8_t>& color);
+    Declaration(const std::string& name, const std::string& kwd);
+    Declaration(const std::string& name, const std::tuple<float, std::string>& length);
+    Declaration(const std::string& name, const std::tuple<uint8_t, uint8_t, uint8_t, uint8_t>& color);
     Declaration(const Declaration& de);
-    string to_string();
+    std::string to_string();
 };
 
 struct Rule {
-    vector<Selector> selectors;
-    vector<Declaration> declarations;
-    Rule(vector<Selector> selectors, vector<Declaration> declarations):
+    std::vector<Selector> selectors;
+    std::vector<Declaration> declarations;
+    Rule(std::vector<Selector> selectors, std::vector<Declaration> declarations):
         selectors(selectors), declarations(declarations) {}
 
     void print(bool is_last_rule);

--- a/css/css_parser.h
+++ b/css/css_parser.h
@@ -4,21 +4,20 @@
 #include <iostream>
 
 using namespace simple_browser;
-using namespace std;
 
 namespace simple_browser_css {
 
 class CssParser: public BaseParser {
 
     public:
-    CssParser(string& source): BaseParser(source) {}
+    CssParser(std::string& source): BaseParser(source) {}
 
-    vector<Rule> parse_css_rules();
+    std::vector<Rule> parse_css_rules();
     Rule parse_css_rule();
-    vector<Selector> parse_selectors();
+    std::vector<Selector> parse_selectors();
     Selector parse_selector();
-    vector<Declaration> parse_declarations();
+    std::vector<Declaration> parse_declarations();
     Declaration parse_declaration();
-    tuple<uint8_t, uint8_t, uint8_t, uint8_t> color_trans(string& hex_color);
+    std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> color_trans(std::string& hex_color);
 };
 }

--- a/html/dom.h
+++ b/html/dom.h
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <iostream>
 
-using namespace std;
 namespace simple_browser_html {
 
 enum DomNodeType {
@@ -16,14 +15,14 @@ enum DomNodeType {
 class DomNode {
     public:
     DomNodeType type;
-    vector<DomNode> child_list;
-    string text;
-    string tag_name;
-    map<string, string> attributes;
+    std::vector<DomNode> child_list;
+    std::string text;
+    std::string tag_name;
+    std::map<std::string, std::string> attributes;
 
     DomNode(){}
-    DomNode(const string& text): text(text), type(TEXT) {}
-    DomNode(const string& tag_name, const map<string, string>& attributes, const vector<DomNode>& child_list):
+    DomNode(const std::string& text): text(text), type(TEXT) {}
+    DomNode(const std::string& tag_name, const std::map<std::string, std::string>& attributes, const std::vector<DomNode>& child_list):
         tag_name(tag_name), attributes(attributes), type(ELEMENT), child_list(child_list) {}
     DomNode(const DomNode& dn) {
         switch (dn.type) {
@@ -37,7 +36,7 @@ class DomNode {
     }
     ~DomNode() {}
     
-    void print(int32_t depth, bool is_last_child, vector<int32_t>& list) const;
+    void print(int32_t depth, bool is_last_child, std::vector<int32_t>& list) const;
 };
 
 void print_dom_node(const DomNode& root, bool is_last_child);

--- a/html/html_parser.h
+++ b/html/html_parser.h
@@ -4,7 +4,6 @@
 #include "dom.h"
 #include "../utils/base_parser.h"
 
-using namespace std;
 using namespace simple_browser;
 
 namespace simple_browser_html {
@@ -12,12 +11,12 @@ namespace simple_browser_html {
 class HtmlParser: public BaseParser {
 
     public:
-    HtmlParser(const string& source): BaseParser(source) {}
+    HtmlParser(const std::string& source): BaseParser(source) {}
 
-    vector<DomNode> parse_dom_nodes();
+    std::vector<DomNode> parse_dom_nodes();
     DomNode parse_dom_node();
     DomNode element_node();
-    map<string, string> parse_attributes();
+    std::map<std::string, std::string> parse_attributes();
     DomNode text_node();
 };
 

--- a/layout/layout_element.h
+++ b/layout/layout_element.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstring>
 #include <string>
-using namespace std;
 namespace simple_browser_layout {
 
 struct Rect {
@@ -10,11 +9,11 @@ struct Rect {
     float width;
     float height;
 
-    string to_string() {
+    std::string to_string() {
         char buf[64];
         memset(buf, 0, sizeof(buf));
         snprintf(buf, sizeof(buf), "%f %f %f %f", x, y, width, height);
-        return string(buf);
+        return std::string(buf);
     }
 };
 
@@ -24,11 +23,11 @@ struct Edge {
     float top;
     float bottom;
 
-    string to_string() {
+    std::string to_string() {
         char buf[64];
         memset(buf, 0, sizeof(buf));
         snprintf(buf, sizeof(buf), "%f %f %f %f", left, right, top, bottom);
-        return string(buf);
+        return std::string(buf);
     }
 };
 
@@ -38,16 +37,16 @@ struct Box {
     struct Edge border;
     struct Edge margin;
 
-    string get_content() {
+    std::string get_content() {
         return "content-xywh: " + content.to_string();
     }
-    string get_padding() {
+    std::string get_padding() {
         return "padding-lrtb: " + padding.to_string();
     }
-    string get_border() {
+    std::string get_border() {
         return "border-lrtb: " + border.to_string();
     }
-    string get_margin() {
+    std::string get_margin() {
         return "margin-lrtb: " + margin.to_string();
     }
 };

--- a/layout/layout_node.h
+++ b/layout/layout_node.h
@@ -13,7 +13,6 @@ typedef struct Fake_Box {
     float pen_y;
 } Fake_Box;
 
-using namespace std;
 using namespace simple_browser_style;
 namespace simple_browser_layout {
 
@@ -21,12 +20,12 @@ class LayoutNode : public StyleDomNode {
     public:
     BoxTypeEnum box_type;
     struct Box box;
-    vector<LayoutNode> child_list;
+    std::vector<LayoutNode> child_list;
 
     LayoutNode(BoxTypeEnum box_type, const StyleDomNode& node);
     LayoutNode(BoxTypeEnum box_type);
     LayoutNode();
-    void print_box_property(int32_t depth, bool is_last_child, vector<int32_t>& list);
+    void print_box_property(int32_t depth, bool is_last_child, std::vector<int32_t>& list);
 
 };
 

--- a/sdl/sdl_drawer.h
+++ b/sdl/sdl_drawer.h
@@ -12,7 +12,6 @@
 #include "sdl_drawer_interface.h"
 #include <unistd.h>
 
-using namespace std;
 namespace simple_browser_sdldrawer {
 
 struct ResourcesStruct {
@@ -49,7 +48,7 @@ public:
     }
 
     bool init_sdldrawer() {
-        string message;
+        std::string message;
 
         if (!(res.window = SDL_CreateWindow("My Awesome Browser", 
             SDL_WINDOWPOS_CENTERED, 0,

--- a/sdl/sdl_drawer_interface.h
+++ b/sdl/sdl_drawer_interface.h
@@ -6,7 +6,6 @@
 #include "../utils/font_manager.h"
 
 using namespace simple_browser_layout;
-using namespace std;
 namespace simple_browser_sdldrawer {
 
 SDL_Rect convert_from_layout_rect(simple_browser_layout::Rect rect)
@@ -40,13 +39,13 @@ Rect_Edge convert_from_layout_edge(simple_browser_layout::Edge edge)
     };
 }
 
-vector<string> make_string_vector(int len, ...) {
-    vector<string> ret;
+std::vector<std::string> make_string_vector(int len, ...) {
+    std::vector<std::string> ret;
     va_list va_p;
     
     va_start(va_p, len);
     for (int i = 0; i < len; ++i) {
-        ret.push_back(string(va_arg(va_p, const char *)));
+        ret.push_back(std::string(va_arg(va_p, const char *)));
     }
     va_end(va_p);
     return ret;    
@@ -55,8 +54,8 @@ vector<string> make_string_vector(int len, ...) {
 class SdlDrawerInterface {
 
 public:
-    vector<Html_Rect> rect_list;
-    vector<Font_Draw_Info> font_list;
+    std::vector<Html_Rect> rect_list;
+    std::vector<Font_Draw_Info> font_list;
     FontManager& font_manager;
     SDL_Renderer *render;
 
@@ -74,7 +73,7 @@ public:
             .l = content_rect.rect.w,
         };
 
-        Value v = Value(make_tuple(TRANSPARENT));
+        Value v = Value(std::make_tuple(TRANSPARENT));
 
         content_rect.color = convert_from_css_color(*find_in_map_or_default(node.property_map, 
             make_string_vector(1, "background"), &v));
@@ -106,14 +105,14 @@ public:
         rect_list.push_back(border_rect);
 
         if (node.type == TEXT) {
-            Value transparent_color(make_tuple(TRANSPARENT));
-            Value black_color(make_tuple(BLACK));
+            Value transparent_color(std::make_tuple(TRANSPARENT));
+            Value black_color(std::make_tuple(BLACK));
 
-            if (const Value *tmp = find_in_map(node.property_map, string("font-size"))) {
+            if (const Value *tmp = find_in_map(node.property_map, std::string("font-size"))) {
                 font_manager.set_font_size(tmp->to_px());
             }
 
-            wstring text = font_manager.convert_to_wstring(node.text);
+            std::wstring text = font_manager.convert_to_wstring(node.text);
             font_manager.draw_string(text, 
                 Font_Color {
                     .font_color = *(SDL_Color *)(&find_in_map_or_default(node.property_map,
@@ -129,7 +128,7 @@ public:
             font_manager.restore_default_font_size();    
         }
 
-        for (vector<LayoutNode>::const_iterator it = node.child_list.begin();
+        for (std::vector<LayoutNode>::const_iterator it = node.child_list.begin();
             it != node.child_list.end(); ++it) {
             iterate_layout_tree(*it);
         }        

--- a/sdl/shape_drawer.h
+++ b/sdl/shape_drawer.h
@@ -3,7 +3,6 @@
 #include <SDL2/SDL_image.h>
 #include <vector>
 
-using namespace std;
 typedef struct RectEdge {
     int t;
     int r;

--- a/style/style_node.h
+++ b/style/style_node.h
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <map>
 
-using namespace std;
 using namespace simple_browser_html;
 using namespace simple_browser_css;
 
@@ -14,12 +13,12 @@ namespace simple_browser_style {
 class StyleDomNode: public DomNode {
     
     public:
-    map<string, Value> property_map;
-    vector<StyleDomNode> child_sdn_list;
+    std::map<std::string, Value> property_map;
+    std::vector<StyleDomNode> child_sdn_list;
 
     public:
-    StyleDomNode(const DomNode& dom_node, const vector<Rule>& rules, 
-        map<string, Value> *extra_property_map): DomNode(dom_node) {
+    StyleDomNode(const DomNode& dom_node, const std::vector<Rule>& rules,
+        std::map<std::string, Value> *extra_property_map): DomNode(dom_node) {
         if (extra_property_map) {
             property_map.insert(extra_property_map->begin(), extra_property_map->end());
         }
@@ -29,9 +28,9 @@ class StyleDomNode: public DomNode {
     ~StyleDomNode() {}
 
     bool match_selector(const Selector& selector, int& weight);
-    void trans_style(const vector<Rule>& rules);
-    void print_property_map(int32_t depth, bool is_last_child, vector<int32_t>& list);
-    string display() const;
+    void trans_style(const std::vector<Rule>& rules);
+    void print_property_map(int32_t depth, bool is_last_child, std::vector<int32_t>& list);
+    std::string display() const;
 };
 
 void style_dom_node_print(StyleDomNode& node, bool is_last_child);

--- a/style/style_node_parser.h
+++ b/style/style_node_parser.h
@@ -3,21 +3,20 @@
 #include <vector>
 #include <map>
 
-using namespace std;
 namespace simple_browser_style {
 
 class StyleDomNodeParser {
 
     public:
     DomNode domNode;
-    vector<Rule> rules;
+    std::vector<Rule> rules;
 
-    StyleDomNodeParser(const DomNode& domNode, const vector<Rule>& rules):
+    StyleDomNodeParser(const DomNode& domNode, const std::vector<Rule>& rules):
         domNode(domNode), rules(rules) {}
 
     // vector<StyleDomNode> parse_style_dom_nodes();
-    StyleDomNode parse_style_dom_node(const DomNode& domNode, const vector<Rule>& rules,
-        map<string, Value> *extra_property_map);
+    StyleDomNode parse_style_dom_node(const DomNode& domNode, const std::vector<Rule>& rules,
+        std::map<std::string, Value> *extra_property_map);
     void print();
 };
 

--- a/utils/base_parser.h
+++ b/utils/base_parser.h
@@ -4,23 +4,22 @@
 #include <assert.h>
 #include "checkers.h"
 
-using namespace std;
 
 namespace simple_browser {
 
 class BaseParser {
     public:
-    string source;
+    std::string source;
     int32_t position;
 
     public:
-    BaseParser(const string& source): source(source), position(0) {}
+    BaseParser(const std::string& source): source(source), position(0) {}
 
     bool eof() {
         return position >= source.length();
     }
 
-    bool starts_with_string(string str) {
+    bool starts_with_string(std::string str) {
         return source.substr(position, str.length()) == str;
     }
 
@@ -39,8 +38,8 @@ class BaseParser {
     };
 
     template <typename F>
-    string consume_position_loop(const F& f) {
-        string ret;
+    std::string consume_position_loop(const F& f) {
+        std::string ret;
         while (position < source.length()
             && f(source[position])) {
             ret.push_back(source[position]);
@@ -49,19 +48,19 @@ class BaseParser {
         return ret;
     }
 
-    void advance_position_string(string str) {
+    void advance_position_string(std::string str) {
         assert(str == source.substr(position, str.length()));
         position += str.length();
     }
 
     /****************************************************************/
     template <typename F>
-    string skip_blank_and_consume_position(const F& f) {
+    std::string skip_blank_and_consume_position(const F& f) {
         advance_position_loop(is_blank);
         return consume_position_loop(f);
     }
 
-    void skip_blank_and_advance_position_string(string str) {
+    void skip_blank_and_advance_position_string(std::string str) {
         advance_position_loop(is_blank);
         advance_position_string(str);
     }

--- a/utils/checkers.h
+++ b/utils/checkers.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <cstdarg>
 
-using namespace std;
 
 __attribute__ ((weak))
 auto is_char = [](char c) -> bool {
@@ -35,12 +34,12 @@ auto is_hex = [](char c) -> bool {
 };
 
 __attribute__ ((weak))
-auto string_equal = [](const string& a, const string& b) -> bool {
+auto string_equal = [](const std::string& a, const std::string& b) -> bool {
     return a == b;
 };
 
 template<typename T, typename F>
-bool in_vector (const vector<T>& list, const T& elem, const F& f) {
+bool in_vector (const std::vector<T>& list, const T& elem, const F& f) {
     for (auto it = list.begin(); it != list.end(); ++it) {
         if (f(*it, elem)) {
             return true;
@@ -50,16 +49,16 @@ bool in_vector (const vector<T>& list, const T& elem, const F& f) {
 }
 
 __attribute__ ((weak))
-auto split_string = [](const string& source, const vector<char>& delimits) -> vector<string> {
-    vector<int> positions;
-    vector<string> ret;
+auto split_string = [](const std::string& source, const std::vector<char>& delimits) -> std::vector<std::string> {
+    std::vector<int> positions;
+    std::vector<std::string> ret;
     for (auto it = source.begin(); it != source.end(); ++it) {
         if (in_vector(delimits, *it, [](char a, char b) -> bool{return a == b;})) {
             positions.push_back(it - source.begin());
         }
     }
     int st;
-    vector<int>::iterator en;
+    std::vector<int>::iterator en;
 
     if (positions.size() > 0) {
         for (en = positions.begin(), st = 0; en <= positions.end(); st = *en + 1, ++en) {
@@ -72,7 +71,7 @@ auto split_string = [](const string& source, const vector<char>& delimits) -> ve
 };
 
 template<typename T, typename F, typename Q>
-bool exist_in_map(map<T, F>& mapping, const T& key, const F& val, const Q& op) {
+bool exist_in_map(std::map<T, F>& mapping, const T& key, const F& val, const Q& op) {
     auto it = mapping.find(key);
     if (it != mapping.end() && op(it->second, val)) {
         return true;
@@ -81,7 +80,7 @@ bool exist_in_map(map<T, F>& mapping, const T& key, const F& val, const Q& op) {
 }
 
 template<typename K, typename V>
-const V* find_in_map(const map<K, V>& mapping, const K& key) {
+const V* find_in_map(const std::map<K, V>& mapping, const K& key) {
     auto it = mapping.find(key);
     if (it == mapping.end()) {
         return nullptr;
@@ -90,7 +89,7 @@ const V* find_in_map(const map<K, V>& mapping, const K& key) {
 }
 
 template<typename K, typename V>
-const V* find_in_map_or_default(const map<K, V>& mapping, const vector<K>& keys, const V* defalut) {
+const V* find_in_map_or_default(const std::map<K, V>& mapping, const std::vector<K>& keys, const V* defalut) {
     const V* ret;
     for (auto pk = keys.cbegin(); pk != keys.cend(); ++pk) {
         if (ret = find_in_map(mapping, *pk)) {
@@ -101,8 +100,8 @@ const V* find_in_map_or_default(const map<K, V>& mapping, const vector<K>& keys,
 }
 
 template <typename T>
-vector<T> make_type_vector(int len, ...) {
-    vector<T> ret;
+std::vector<T> make_type_vector(int len, ...) {
+    std::vector<T> ret;
     va_list va_p;
     
     va_start(va_p, len);

--- a/utils/dom_elements.h
+++ b/utils/dom_elements.h
@@ -1,9 +1,8 @@
 #pragma once
 #include <string>
 #include <vector>
-using namespace std;
-    
-const vector<string> block_elements = {
+
+const std::vector<std::string> block_elements = {
     "address",
     "article",
     "aside",
@@ -40,7 +39,7 @@ const vector<string> block_elements = {
     "video",
 };
 
-const vector<string> inline_elements = {
+const std::vector<std::string> inline_elements = {
     "a",
     "abbr",
     "acronym",

--- a/utils/font_manager.h
+++ b/utils/font_manager.h
@@ -24,7 +24,6 @@ typedef struct Font_Draw_Info {
     SDL_Color background_color;
 } Font_Draw_Info;
 
-using namespace std;
 class FontManager {
 public:
     FT_Library ft_lib;
@@ -36,11 +35,11 @@ public:
     ~FontManager();
     void set_font_size(int size);
     void restore_default_font_size();
-    tuple<int, int> get_string_width_length(wstring str);
-    void draw_string(wstring str, Font_Color color, Font_Position start_position, 
-        vector<Font_Draw_Info>& font_list, SDL_Renderer *render);
-    wstring convert_to_wstring(string str);
+    std::tuple<int, int> get_string_width_length(std::wstring str);
+    void draw_string(std::wstring str, Font_Color color, Font_Position start_position,
+        std::vector<Font_Draw_Info>& font_list, SDL_Renderer *render);
+    std::wstring convert_to_wstring(std::string str);
 private:
-    void draw_font(wchar_t ch, Font_Color color, Font_Position& position, 
-        vector<Font_Draw_Info>& font_list, SDL_Renderer *render);
+    void draw_font(wchar_t ch, Font_Color color, Font_Position& position,
+        std::vector<Font_Draw_Info>& font_list, SDL_Renderer *render);
 };


### PR DESCRIPTION
## Summary
- remove `using namespace std` from header files
- prefix standard library types with `std::`

## Testing
- `make -C html integrate`
- `make -C css integrate`
- `make -C style integrate` *(fails: SDL2 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68543a11516483298d0ccafdd88e3267