### PR TITLE
Add include guard to FontManager

### DIFF
--- a/utils/font_manager.h
+++ b/utils/font_manager.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <ft2build.h>
 #include <freetype/freetype.h>
 #include <freetype/ftimage.h>


### PR DESCRIPTION
## Summary
- prevent multiple inclusion of `font_manager.h` by adding `#pragma once`

## Testing
- `make -C style` *(fails: SDL2/SDL.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543a0e152c83298358f43d90ff3311